### PR TITLE
Update applyMiddleware to return

### DIFF
--- a/lib/applyMiddleware.js
+++ b/lib/applyMiddleware.js
@@ -40,7 +40,7 @@ module.exports = function applyMiddleware (middleware, handler) {
         await middleware[mwFn](req, res);
       }
     
-      await handler(req, res);
+      return await handler(req, res);
     
     } catch (err) {
       let errorHandlers = sets.getSet('errorHandler');

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 const test = require('ava');
 const { applyMiddleware, createSet, getSet } = require('../lib');
 const httpMocks = require('node-mocks-http');
+const { run } = require('micro');
 
 function reqUserMiddleware(req, res) {
     req.user = { id: 'foobar' };
@@ -119,4 +120,21 @@ test('Sets that references other sets', async t => {
     });
 
     await fn(mockReq, mockRes);
+});
+
+test('Async/Await function with return', async t => {
+    t.plan(1);
+
+    const mockReq = httpMocks.createRequest();
+    const mockRes = httpMocks.createResponse();
+
+    let fn = applyMiddleware([], async (req, res) => {
+        return {
+            hello: 'world',
+        };
+    });
+
+    await run(mockReq, mockRes, fn);
+
+    t.deepEqual(JSON.parse(mockRes._getData()), { hello: 'world' });
 });


### PR DESCRIPTION
Hello!

I noticed a bug in this library where if you use an async route which returns, it does not finish the request. For example, using `applyMiddeware` with this function does not work:

```
module.exports = async (req, res) => {
  return 'Ready!'
}
```

However, this does:
```
module.exports = (req, res) => {
  res.end('Ready!')
}
```

Adding a `return` will ensure that both methods will work.